### PR TITLE
feat: start stop step functionality

### DIFF
--- a/include/stonefish_ros2/ROS2ConsoleSimulationApp.h
+++ b/include/stonefish_ros2/ROS2ConsoleSimulationApp.h
@@ -38,6 +38,9 @@ namespace sf
         ROS2ConsoleSimulationApp(std::string title, std::string dataPath, ROS2SimulationManager* sim);
         void Startup();
         void Shutdown();
+        void Step();
+        void Pause();
+        void Resume();
     };
 }
 

--- a/include/stonefish_ros2/ROS2GraphicalSimulationApp.h
+++ b/include/stonefish_ros2/ROS2GraphicalSimulationApp.h
@@ -38,6 +38,10 @@ namespace sf
         ROS2GraphicalSimulationApp(std::string title, std::string dataPath, RenderSettings s, HelperSettings h, ROS2SimulationManager* sim);
         void Startup();
         void Tick();
+        void Shutdown();
+        void Step();
+        void Pause();
+        void Resume();
     };
 }
 

--- a/src/stonefish_ros2/ROS2ConsoleSimulationApp.cpp
+++ b/src/stonefish_ros2/ROS2ConsoleSimulationApp.cpp
@@ -45,4 +45,19 @@ void ROS2ConsoleSimulationApp::Shutdown()
     CleanUp();
 }
 
+void ROS2ConsoleSimulationApp::Step()
+{
+    StepSimulation();
+}
+
+void ROS2ConsoleSimulationApp::Pause()
+{
+    StopSimulation();
+}
+
+void ROS2ConsoleSimulationApp::Resume()
+{
+    ResumeSimulation();
+}
+
 }

--- a/src/stonefish_ros2/ROS2GraphicalSimulationApp.cpp
+++ b/src/stonefish_ros2/ROS2GraphicalSimulationApp.cpp
@@ -50,4 +50,24 @@ void ROS2GraphicalSimulationApp::Tick()
     }
 }
 
+void ROS2GraphicalSimulationApp::Shutdown()
+{
+    CleanUp();
+}
+
+void ROS2GraphicalSimulationApp::Step()
+{
+    StepSimulation();
+}
+
+void ROS2GraphicalSimulationApp::Pause()
+{
+    StopSimulation();
+}
+
+void ROS2GraphicalSimulationApp::Resume()
+{
+    ResumeSimulation();
+}
+
 }

--- a/src/stonefish_simulator_nogpu.cpp
+++ b/src/stonefish_simulator_nogpu.cpp
@@ -27,7 +27,6 @@
 #include <Stonefish/utils/SystemUtil.hpp>
 #include "stonefish_ros2/ROS2SimulationManager.h"
 #include "stonefish_ros2/ROS2ConsoleSimulationApp.h"
-#include <std_msgs/msg/bool.hpp>
 
 #include <std_srvs/srv/trigger.hpp>
 

--- a/src/stonefish_simulator_nogpu.cpp
+++ b/src/stonefish_simulator_nogpu.cpp
@@ -27,6 +27,7 @@
 #include <Stonefish/utils/SystemUtil.hpp>
 #include "stonefish_ros2/ROS2SimulationManager.h"
 #include "stonefish_ros2/ROS2ConsoleSimulationApp.h"
+#include <std_msgs/msg/bool.hpp>
 
 using namespace std::chrono_literals;
 
@@ -38,8 +39,30 @@ public:
                            sf::Scalar rate) 
                            : Node("stonefish_simulator_nogpu")
     {   
+        step_sub_ = this->create_subscription<std_msgs::msg::Bool>(
+            "step_simulation", 1, 
+            [this](std_msgs::msg::Bool::SharedPtr msg) {
+                if (msg->data) {
+                    this->Step();
+                }
+            });
+        pause_sub_ = this->create_subscription<std_msgs::msg::Bool>(
+            "pause_simulation", 1, 
+            [this](std_msgs::msg::Bool::SharedPtr msg) {
+                if (msg->data) {
+                    this->Pause();
+                }
+            });
+        resume_sub_ = this->create_subscription<std_msgs::msg::Bool>(
+            "resume_simulation", 1, 
+            [this](std_msgs::msg::Bool::SharedPtr msg) {
+                if (msg->data) {
+                    this->Resume();
+                }
+            });
         sf::ROS2SimulationManager* manager = new sf::ROS2SimulationManager(rate, scenarioPath, std::shared_ptr<rclcpp::Node>(this));
         app_ = std::shared_ptr<sf::ROS2ConsoleSimulationApp>(new sf::ROS2ConsoleSimulationApp("Stonefish Simulator", dataPath, manager));
+        app_->
         app_->Startup();
     };
 
@@ -48,8 +71,27 @@ public:
         app_->Shutdown();
     };
 
+    void Step()
+    {
+        app_->Step();
+    };
+
+    void Pause()
+    {
+        app_->Pause();
+    };
+
+    void Resume()
+    {
+        app_->Resume();
+    };
+
 private:
     std::shared_ptr<sf::ROS2ConsoleSimulationApp> app_;
+    rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr pause_sub_;
+    rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr resume_sub_;
+    rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr step_sub_;
+
 };
 
 int main(int argc, char **argv)


### PR DESCRIPTION
Added ability to pause, resume and step the simulation through services. Example:
```bash
ros2 service call /stonefish_ros2/step_simulation std_srvs/srv/Trigger 
requester: making request: std_srvs.srv.Trigger_Request()

response:
std_srvs.srv.Trigger_Response(success=True, message='Simulation stepped successfully.')
```