### PR TITLE
feat: set environmental variables with services

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,8 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "srv/SonarSettings.srv"
   "srv/SonarSettings2.srv"
   "srv/Respawn.srv"
+  "srv/SetJerlov.srv"
+  "srv/SetSunParams.srv"
   DEPENDENCIES std_msgs std_srvs geometry_msgs
 )
 rosidl_get_typesupport_target(cpp_typesupport_target ${PROJECT_NAME} rosidl_typesupport_cpp)

--- a/src/stonefish_simulator.cpp
+++ b/src/stonefish_simulator.cpp
@@ -66,6 +66,10 @@ public:
             "set_jerlov",
             std::bind(&StonefishNode::set_jerlov_callback, this, _1, _2));
 
+        set_sun_params_srv_ = this->create_service<stonefish_ros2::srv::SetSunParams>(
+            "set_sun_params",
+            std::bind(&StonefishNode::set_sun_params_callback, this, _1, _2));
+
         sf::ROS2SimulationManager* manager = new sf::ROS2SimulationManager(rate, scenarioPath, std::shared_ptr<rclcpp::Node>(this));
         app_ = std::shared_ptr<sf::ROS2GraphicalSimulationApp>(new sf::ROS2GraphicalSimulationApp("Stonefish Simulator", 
                                                                                                  dataPath, s, h, manager));
@@ -161,6 +165,21 @@ private:
         app_->getSimulationManager()->getOcean()->setWaterType(req->jerlov);
         res->success = true;
         res->message = "Jerlov water type successfully set to %f." + std::to_string(req->jerlov);
+    }
+
+    void set_sun_params_callback(
+        const std::shared_ptr<stonefish_ros2::srv::SetSunParams::Request> req,
+        std::shared_ptr<stonefish_ros2::srv::SetSunParams::Response> res)
+    {
+        if (req->azimuth < -180.0f || req->azimuth > 180.0f || req->elevation < -10.0f || req->elevation > 90.0f)
+        {
+            res->success = false;
+            res->message = "Invalid sun parameters. Azimuth must be in [-180, 180] and elevation in [-10, 90].";
+            return;
+        }
+        app_->getSimulationManager()->getAtmosphere()->SetSunPosition(req->azimuth, req->elevation);
+        res->success = true;
+        res->message = "Sun parameters successfully set to azimuth: " + std::to_string(req->azimuth) + ", elevation: " + std::to_string(req->elevation) + ".";
     }
             
     rclcpp::Service<std_srvs::srv::Trigger>::SharedPtr pause_srv_;

--- a/srv/SetJerlov.srv
+++ b/srv/SetJerlov.srv
@@ -1,0 +1,4 @@
+float32 jerlov # Water type
+---
+bool success
+string message

--- a/srv/SetSunParams.srv
+++ b/srv/SetSunParams.srv
@@ -1,0 +1,5 @@
+float32 azimuth
+float32 elevation
+---
+bool success
+string message


### PR DESCRIPTION
Can now set jerlov, sun (azi, elev) and particles with services. Usage, with handling of invalid values:
### Jerlov
```bash
ros2 service call /stonefish_ros2/set_jerlov stonefish_ros2/srv/SetJerlov "{jerlov: 0.4}"
requester: making request: stonefish_ros2.srv.SetJerlov_Request(jerlov=0.4)

response:
stonefish_ros2.srv.SetJerlov_Response(success=True, message='Jerlov water type successfully set to %f.0.400000')
```

```bash
ros2 service call /stonefish_ros2/set_jerlov stonefish_ros2/srv/SetJerlov "{jerlov: 1.1}"
requester: making request: stonefish_ros2.srv.SetJerlov_Request(jerlov=1.1)

response:
stonefish_ros2.srv.SetJerlov_Response(success=False, message='Invalid Jerlov water type. Must be between 0 and 1.')
```

### Sun
```bash
ros2 service call /stonefish_ros2/set_sun_params stonefish_ros2/srv/SetSunParams "{azimuth: 179.0, elevation: 45.0}"
requester: making request: stonefish_ros2.srv.SetSunParams_Request(azimuth=179.0, elevation=45.0)

response:
stonefish_ros2.srv.SetSunParams_Response(success=True, message='Sun parameters successfully set to azimuth: 179.000000, elevation: 45.000000.')
```
```bash
ros2 service call /stonefish_ros2/set_sun_params stonefish_ros2/srv/SetSunParams "{azimuth: 179.0, elevation: 95.0}"
requester: making request: stonefish_ros2.srv.SetSunParams_Request(azimuth=179.0, elevation=95.0)

response:
stonefish_ros2.srv.SetSunParams_Response(success=False, message='Invalid sun parameters. Azimuth must be in [-180, 180] and elevation in [-10, 90].')
```

### Particles
```bash
ros2 service call /stonefish_ros2/set_particles_on std_srvs/srv/SetBool "{data: false}"
requester: making request: std_srvs.srv.SetBool_Request(data=False)

response:
std_srvs.srv.SetBool_Response(success=True, message='Particles disabled.')
```
```bash
ros2 service call /stonefish_ros2/set_particles_on std_srvs/srv/SetBool "{data: false}"
requester: making request: std_srvs.srv.SetBool_Request(data=False)

response:
std_srvs.srv.SetBool_Response(success=False, message='Particles are already disabled.')
```
